### PR TITLE
feat(meta.rs): rename `dank` to `Cycles`

### DIFF
--- a/xtc/src/meta.rs
+++ b/xtc/src/meta.rs
@@ -12,7 +12,7 @@ pub struct TokenMetaData<'a> {
 #[query]
 pub fn meta() -> TokenMetaData<'static> {
     TokenMetaData {
-        name: "Dank",
+        name: "Cycles",
         symbol: "XTC",
         decimal: 12,
         features: vec!["history"],


### PR DESCRIPTION
This change is confirmed by Harrison.

It will change the name as returned from the `name` function against the canister as well, as that is populated from metadata.

So:
```bash
dfx canister --network=ic call xtc name
# (opt "Cycles")
```