### PR TITLE
Added transcation fees for burn, mint, and transfer.

### DIFF
--- a/piggy-bank/src/lib.rs
+++ b/piggy-bank/src/lib.rs
@@ -3,7 +3,7 @@ use ic_cdk::*;
 use ic_cdk_macros::*;
 use serde::*;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, CandidType)]
 struct PerformMintArgs {
     canister: Principal,
     account: Option<Principal>,

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -144,7 +144,7 @@ fn mint(account: Option<Principal>) -> Result<TransactionId, MintError> {
     Ok(id)
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, CandidType)]
 struct BurnArguments {
     canister_id: Principal,
     amount: u64,

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -39,22 +39,24 @@ impl Ledger {
 
     #[inline]
     pub fn deposit(&mut self, account: Principal, amount: u64) {
-        StatsData::deposit(amount);
+        let fee = 2_000_000_000;
+        StatsData::deposit(amount - fee);
         match self.0.entry(account) {
             Entry::Occupied(mut e) => {
-                e.insert(*e.get() + amount);
+                e.insert(*e.get() + amount - fee);
             }
             Entry::Vacant(e) => {
-                e.insert(amount);
+                e.insert(amount - fee);
             }
         }
     }
 
     #[inline]
     pub fn withdraw(&mut self, account: &Principal, amount: u64) -> Result<(), ()> {
+        let fee = 2_000_000_000;
         let balance = match self.0.get_mut(&account) {
-            Some(balance) if *balance >= amount => {
-                *balance -= amount;
+            Some(balance) if *balance >= (amount + fee) => {
+                *balance -= amount + fee;
                 *balance
             }
             _ => return Err(()),

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -249,7 +249,7 @@ mod tests {
         assert!(ledger.withdraw(&alice(), 1000).is_err());
         assert_eq!(ledger.balance(&alice()), 900);
 
-        ledger.deposit(alice(), 100);
+        ledger.deposit(alice(), 100_000_000_000);
         assert!(ledger.withdraw(&alice(), 1000).is_ok());
         assert_eq!(ledger.balance(&alice()), 0);
         assert_eq!(ledger.balance(&bob()), 0);

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -78,7 +78,7 @@ pub fn balance(account: Option<Principal>) -> u64 {
     ledger.balance(&account.unwrap_or_else(|| caller()))
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, CandidType)]
 struct TransferArguments {
     to: Principal,
     amount: u64,


### PR DESCRIPTION
Added the fixed transaction fee of 2 billion cycles for every burn, mint, and transfer request.