### PR TITLE
fix(cycles_wallet): change canistercall tran record to have canister id

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "dfx": "0.7.2",
+  "dfx": "0.8.0",
   "canisters": {
     "xtc": {
       "build": "node build.js",

--- a/piggy-bank/src/lib.rs
+++ b/piggy-bank/src/lib.rs
@@ -3,7 +3,7 @@ use ic_cdk::*;
 use ic_cdk_macros::*;
 use serde::*;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, CandidType)]
 struct PerformMintArgs {
     canister: Principal,
     account: Option<Principal>,

--- a/xtc/src/cycles_wallet.rs
+++ b/xtc/src/cycles_wallet.rs
@@ -60,7 +60,7 @@ async fn call(args: CallCanisterArgs) -> Result<CallResult, String> {
                 cycles,
                 fee: 0,
                 kind: TransactionKind::CanisterCalled {
-                    canister: user.clone(),
+                    canister: args.canister.clone(),
                     method_name: args.method_name,
                 },
             };

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -76,7 +76,7 @@ pub fn balance(account: Option<Principal>) -> u64 {
     ledger.balance(&account.unwrap_or_else(|| caller()))
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, CandidType)]
 struct TransferArguments {
     to: Principal,
     amount: u64,
@@ -142,7 +142,7 @@ fn mint(account: Option<Principal>) -> Result<TransactionId, MintError> {
     Ok(id)
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, CandidType)]
 struct BurnArguments {
     canister_id: Principal,
     amount: u64,


### PR DESCRIPTION
Previously it was wrongly the callee. Separately we will need to restructure the record to include
the `from` principal id.

## Clubhouse

[ch23575] - [CanisterCall transaction entry is has wrong `canister` value](https://app.clubhouse.io/terminalsystems/story/23575/canistercall-transaction-entry-is-has-wrong-canister-value)