### PR TITLE
[WIP] Add transaction fee

### DIFF
--- a/candid/xtc.did
+++ b/candid/xtc.did
@@ -88,6 +88,7 @@ type TokenMetaData = record {
 
 type Stats = record {
     supply: nat;
+    fee: nat;
     history_events: nat64;
     balance: nat64;
     // Usage statistics

--- a/xtc/src/cycles_wallet.rs
+++ b/xtc/src/cycles_wallet.rs
@@ -16,28 +16,28 @@ use ic_kit::{get_context, Context, Principal};
 use serde::*;
 
 #[query]
-fn name() -> Option<&'static str> {
+pub fn name() -> Option<&'static str> {
     Some(meta().name)
 }
 
 #[derive(CandidType, Deserialize)]
-struct CallCanisterArgs {
-    canister: Principal,
-    method_name: String,
+pub struct CallCanisterArgs {
+    pub canister: Principal,
+    pub method_name: String,
     #[serde(with = "serde_bytes")]
-    args: Vec<u8>,
-    cycles: u64,
+    pub args: Vec<u8>,
+    pub cycles: u64,
 }
 
 #[derive(CandidType, Deserialize)]
-struct CallResult {
+pub struct CallResult {
     #[serde(with = "serde_bytes")]
-    r#return: Vec<u8>,
+    pub r#return: Vec<u8>,
 }
 
 /// Forward a call to another canister.
 #[update(name = "wallet_call")]
-async fn call(args: CallCanisterArgs) -> Result<CallResult, String> {
+pub async fn call(args: CallCanisterArgs) -> Result<CallResult, String> {
     IsShutDown::guard();
 
     let ic = get_context();
@@ -96,13 +96,13 @@ async fn call(args: CallCanisterArgs) -> Result<CallResult, String> {
 // Create canister call
 
 #[derive(CandidType, Deserialize)]
-struct CreateCanisterArgs {
-    cycles: u64,
-    controller: Option<Principal>,
+pub struct CreateCanisterArgs {
+    pub cycles: u64,
+    pub controller: Option<Principal>,
 }
 
 #[update(name = "wallet_create_canister")]
-async fn create_canister(args: CreateCanisterArgs) -> Result<WithCanisterId, String> {
+pub async fn create_canister(args: CreateCanisterArgs) -> Result<WithCanisterId, String> {
     IsShutDown::guard();
 
     let ic = get_context();
@@ -167,12 +167,12 @@ async fn create_canister(args: CreateCanisterArgs) -> Result<WithCanisterId, Str
 }
 
 #[derive(CandidType)]
-struct BalanceResult {
-    amount: u64,
+pub struct BalanceResult {
+    pub amount: u64,
 }
 
 #[query]
-fn wallet_balance() -> BalanceResult {
+pub fn wallet_balance() -> BalanceResult {
     let ic = get_context();
     let ledger = ic.get::<Ledger>();
     let amount = ledger.balance(&ic.caller());
@@ -180,13 +180,13 @@ fn wallet_balance() -> BalanceResult {
 }
 
 #[derive(CandidType, Deserialize)]
-struct SendCyclesArgs {
-    canister: Principal,
-    amount: u64,
+pub struct SendCyclesArgs {
+    pub canister: Principal,
+    pub amount: u64,
 }
 
 #[update]
-async fn wallet_send(args: SendCyclesArgs) -> Result<(), String> {
+pub async fn wallet_send(args: SendCyclesArgs) -> Result<(), String> {
     IsShutDown::guard();
 
     let ic = get_context();
@@ -242,139 +242,10 @@ async fn wallet_send(args: SendCyclesArgs) -> Result<(), String> {
 }
 
 #[update]
-async fn wallet_create_wallet(_: CreateCanisterArgs) -> Result<WithCanisterId, String> {
+pub async fn wallet_create_wallet(_: CreateCanisterArgs) -> Result<WithCanisterId, String> {
     let ic = get_context();
     crate::progress().await;
     Ok(WithCanisterId {
         canister_id: ic.id(),
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ledger::Ledger;
-    use ic_kit::{async_test, Context, MockContext, RejectionCode};
-    use ic_kit::{mock_principals, Method, RawHandler};
-    use std::fmt::Debug;
-    use std::future::Future;
-    use std::pin::Pin;
-
-    fn reset_ledger(ctx: &mut MockContext) {
-        let ledger = ctx.get_mut::<Ledger>();
-        ledger.deposit(Principal::anonymous(), 3 * 10_000_000_000_000);
-        ledger.load(vec![
-            (mock_principals::alice(), 10_000_000_000_000),
-            (mock_principals::bob(), 10_000_000_000_000),
-            (mock_principals::john(), 10_000_000_000_000),
-        ]);
-    }
-
-    /// General method to test the behaviour of fee implementation of methods.
-    async fn test_fee<T: CandidType + Clone, O, E: Debug>(
-        response: T,
-        cb: Box<dyn Fn(u64) -> Pin<Box<dyn Future<Output = Result<O, E>>>>>,
-    ) {
-        let ctx = MockContext::new()
-            .with_caller(mock_principals::alice())
-            .inject();
-
-        // Consumes all
-        reset_ledger(ctx);
-        ctx.clear_handlers();
-        ctx.use_handler(
-            Method::new()
-                .response(response.clone())
-                .cycles_consume(2_000),
-        );
-        cb(1_000).await.expect("Unexpected error.");
-        ctx.call_state_reset();
-
-        assert_eq!(
-            ctx.get::<Ledger>().balance(&mock_principals::alice()),
-            10_000_000_000_000 - 1_000 - compute_fee(1_000)
-        );
-
-        // With refund.
-        reset_ledger(ctx);
-        cb(10_000).await.expect("Unexpected error.");
-        ctx.call_state_reset();
-
-        assert_eq!(
-            ctx.get::<Ledger>().balance(&mock_principals::alice()),
-            10_000_000_000_000 - 2_000 - compute_fee(2_000)
-        );
-
-        // With error.
-        reset_ledger(ctx);
-        ctx.clear_handlers();
-        ctx.use_handler(RawHandler::raw(Box::new(|_, _, _, _| {
-            Err((
-                RejectionCode::DestinationInvalid,
-                "Canister not found.".into(),
-            ))
-        })));
-        cb(10_000).await.err().expect("Expected Err response.");
-        ctx.call_state_reset();
-
-        assert_eq!(
-            ctx.get::<Ledger>().balance(&mock_principals::alice()),
-            10_000_000_000_000
-        );
-    }
-
-    #[async_test]
-    async fn wallet_call_fee() {
-        test_fee(
-            (),
-            Box::new(|cycles| {
-                Box::pin(async move {
-                    call(CallCanisterArgs {
-                        canister: mock_principals::john(),
-                        method_name: "xxx".to_string(),
-                        args: vec![],
-                        cycles,
-                    })
-                    .await
-                })
-            }),
-        )
-        .await;
-    }
-
-    #[async_test]
-    async fn create_canister_fee() {
-        test_fee(
-            WithCanisterId {
-                canister_id: mock_principals::xtc(),
-            },
-            Box::new(|cycles| {
-                Box::pin(async move {
-                    create_canister(CreateCanisterArgs {
-                        cycles,
-                        controller: None,
-                    })
-                    .await
-                })
-            }),
-        )
-        .await;
-    }
-
-    #[async_test]
-    async fn send_fee() {
-        test_fee(
-            (),
-            Box::new(|cycles| {
-                Box::pin(async move {
-                    wallet_send(SendCyclesArgs {
-                        canister: mock_principals::xtc(),
-                        amount: cycles,
-                    })
-                    .await
-                })
-            }),
-        )
-        .await;
-    }
 }

--- a/xtc/src/fee.rs
+++ b/xtc/src/fee.rs
@@ -1,5 +1,16 @@
 /// Compute the fee for the given transaction amount. Any implementation of this method
 /// should guarantee that for an amount A > B, compute_fee(A) >= compute_fee(B).
+#[cfg(not(test))]
 pub fn compute_fee(_: u64) -> u64 {
     2_000_000_000
+}
+
+// Used for testing.
+#[cfg(test)]
+pub fn compute_fee(cycles: u64) -> u64 {
+    if cycles > 5_000 {
+        3_500_000_000
+    } else {
+        2_000_000_000
+    }
 }

--- a/xtc/src/fee.rs
+++ b/xtc/src/fee.rs
@@ -1,0 +1,5 @@
+/// Compute the fee for the given transaction amount. Any implementation of this method
+/// should guarantee that for an amount A > B, compute_fee(A) >= compute_fee(B).
+pub fn compute_fee(_: u64) -> u64 {
+    2_000_000_000
+}

--- a/xtc/src/history.rs
+++ b/xtc/src/history.rs
@@ -52,6 +52,7 @@ impl HistoryBuffer {
             panic!("Transaction is expected to have a non-zero amount.")
         }
 
+        StatsData::capture_fee(transaction.fee);
         StatsData::increment(match &transaction.kind {
             TransactionKind::Transfer { .. } => CountTarget::Transfer,
             TransactionKind::Mint { .. } => CountTarget::Mint,

--- a/xtc/src/history.rs
+++ b/xtc/src/history.rs
@@ -49,7 +49,9 @@ impl HistoryBuffer {
                 return 0;
             }
 
-            panic!("Transaction is expected to have a non-zero amount.")
+            if transaction.fee == 0 {
+                panic!("Transaction is expected to have a non-zero amount.")
+            }
         }
 
         StatsData::capture_fee(transaction.fee);

--- a/xtc/src/lib.rs
+++ b/xtc/src/lib.rs
@@ -7,6 +7,9 @@ mod meta;
 mod stats;
 mod upgrade;
 
+#[cfg(test)]
+mod tests;
+
 /// Perform only one pending async task, returns whether an async call was performed
 /// as the result of calling this method or not.
 /// This method should only be called from updates.

--- a/xtc/src/lib.rs
+++ b/xtc/src/lib.rs
@@ -1,4 +1,5 @@
 mod cycles_wallet;
+mod fee;
 mod history;
 mod ledger;
 mod management;

--- a/xtc/src/stats.rs
+++ b/xtc/src/stats.rs
@@ -5,8 +5,38 @@ use ic_kit::{get_context, Context};
 use serde::Deserialize;
 
 #[derive(Deserialize, CandidType, Clone, Default)]
+pub struct StatsDataV0 {
+    supply: Nat,
+    history_events: u64,
+    balance: u64,
+    // Usage statistics
+    transfers_count: u64,
+    mints_count: u64,
+    burns_count: u64,
+    proxy_calls_count: u64,
+    canisters_created_count: u64,
+}
+
+impl From<StatsDataV0> for StatsData {
+    fn from(s: StatsDataV0) -> Self {
+        StatsData {
+            supply: s.supply,
+            fee: Nat::default(),
+            history_events: s.history_events,
+            balance: s.balance,
+            transfers_count: s.transfers_count,
+            mints_count: s.mints_count,
+            burns_count: s.burns_count,
+            proxy_calls_count: s.proxy_calls_count,
+            canisters_created_count: s.canisters_created_count,
+        }
+    }
+}
+
+#[derive(Deserialize, CandidType, Clone, Default)]
 pub struct StatsData {
     supply: Nat,
+    fee: Nat,
     history_events: u64,
     balance: u64,
     // Usage statistics
@@ -67,6 +97,13 @@ impl StatsData {
         let ic = get_context();
         let stats = ic.get_mut::<StatsData>();
         stats.supply -= amount;
+    }
+
+    #[inline]
+    pub fn capture_fee(amount: u64) {
+        let ic = get_context();
+        let stats = ic.get_mut::<StatsData>();
+        stats.fee += amount;
     }
 }
 

--- a/xtc/src/tests.rs
+++ b/xtc/src/tests.rs
@@ -1,0 +1,130 @@
+use crate::fee::compute_fee;
+use crate::ledger::Ledger;
+use ic_kit::candid::CandidType;
+use ic_kit::interfaces::management::WithCanisterId;
+use ic_kit::{async_test, Context, MockContext, Principal, RejectionCode};
+use ic_kit::{mock_principals, Method, RawHandler};
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+
+fn reset_ledger(ctx: &mut MockContext) {
+    let ledger = ctx.get_mut::<Ledger>();
+    ledger.deposit(Principal::anonymous(), 3 * 10_000_000_000_000);
+    ledger.load(vec![
+        (mock_principals::alice(), 10_000_000_000_000),
+        (mock_principals::bob(), 10_000_000_000_000),
+        (mock_principals::john(), 10_000_000_000_000),
+    ]);
+}
+
+/// General method to test the behaviour of fee implementation of methods.
+async fn test_fee<T: CandidType + Clone, O, E: Debug>(
+    response: T,
+    cb: Box<dyn Fn(u64) -> Pin<Box<dyn Future<Output = Result<O, E>>>>>,
+) {
+    let ctx = MockContext::new()
+        .with_caller(mock_principals::alice())
+        .inject();
+
+    // Consumes all
+    reset_ledger(ctx);
+    ctx.clear_handlers();
+    ctx.use_handler(
+        Method::new()
+            .response(response.clone())
+            .cycles_consume(2_000),
+    );
+    cb(1_000).await.expect("Unexpected error.");
+    ctx.call_state_reset();
+
+    assert_eq!(
+        ctx.get::<Ledger>().balance(&mock_principals::alice()),
+        10_000_000_000_000 - 1_000 - compute_fee(1_000)
+    );
+
+    // With refund.
+    reset_ledger(ctx);
+    cb(10_000).await.expect("Unexpected error.");
+    ctx.call_state_reset();
+
+    assert_eq!(
+        ctx.get::<Ledger>().balance(&mock_principals::alice()),
+        10_000_000_000_000 - 2_000 - compute_fee(2_000)
+    );
+
+    // With error.
+    reset_ledger(ctx);
+    ctx.clear_handlers();
+    ctx.use_handler(RawHandler::raw(Box::new(|_, _, _, _| {
+        Err((
+            RejectionCode::DestinationInvalid,
+            "Canister not found.".into(),
+        ))
+    })));
+    cb(10_000).await.err().expect("Expected Err response.");
+    ctx.call_state_reset();
+
+    assert_eq!(
+        ctx.get::<Ledger>().balance(&mock_principals::alice()),
+        10_000_000_000_000
+    );
+}
+
+#[async_test]
+async fn wallet_call_fee() {
+    use crate::cycles_wallet::*;
+    test_fee(
+        (),
+        Box::new(|cycles| {
+            Box::pin(async move {
+                call(CallCanisterArgs {
+                    canister: mock_principals::john(),
+                    method_name: "xxx".to_string(),
+                    args: vec![],
+                    cycles,
+                })
+                .await
+            })
+        }),
+    )
+    .await;
+}
+
+#[async_test]
+async fn create_canister_fee() {
+    use crate::cycles_wallet::*;
+    test_fee(
+        WithCanisterId {
+            canister_id: mock_principals::xtc(),
+        },
+        Box::new(|cycles| {
+            Box::pin(async move {
+                create_canister(CreateCanisterArgs {
+                    cycles,
+                    controller: None,
+                })
+                .await
+            })
+        }),
+    )
+    .await;
+}
+
+#[async_test]
+async fn send_fee() {
+    use crate::cycles_wallet::*;
+    test_fee(
+        (),
+        Box::new(|cycles| {
+            Box::pin(async move {
+                wallet_send(SendCyclesArgs {
+                    canister: mock_principals::xtc(),
+                    amount: cycles,
+                })
+                .await
+            })
+        }),
+    )
+    .await;
+}


### PR DESCRIPTION
This PR adds a constant transaction fee of 2B cycles for every transaction, keeps track of total volume of captured fees and handles the upgrade logic required for deployment.