### PR TITLE
Adding overflow/underflow protection in release mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
           args: --all-features --no-fail-fast
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Cpanic=abort -Zpanic_abort_tests'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
 
       - name: Collect Coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ members = [
 [profile.release]
 lto = true
 opt-level = 'z'
+overflow-checks = true
+
+[profile.bench]
+overflow-checks = true

--- a/xtc/src/lib.rs
+++ b/xtc/src/lib.rs
@@ -19,3 +19,32 @@ pub async fn progress() -> bool {
     let history = storage::get_mut::<history::HistoryBuffer>();
     history.progress().await
 }
+
+#[test]
+#[should_panic]
+fn integer_underflow_in_release_build_test() // test integer overflow in release mode
+{
+    // disable compile time checks for overflow for constant expressions
+    #![allow(arithmetic_overflow)]
+
+    let u: u8 = 0 - 1;
+    sink(u);
+}
+
+#[test]
+#[should_panic]
+fn integer_overflow_in_release_build_test() // test integer overflow in release mode
+{
+    // disable compile time checks for overflow for constant expressions
+    #![allow(arithmetic_overflow)]
+
+    let u: u8 = 255 + 1;
+    sink(u);
+}
+
+// Declarding function called sink, that has side-effects cause by the #[no_mangle]
+// attribute. A function with side-effects and the parameters will not be optimized
+// away by rustc.
+#[cfg(test)]
+#[no_mangle]
+fn sink(_: u8) {}


### PR DESCRIPTION
In release build we will now have runtime checks whether integers overflow or
underflow. By doing so, one of the most common smart contract security
weaknesses are prevented.

issue: Guard against overflows on balances [ch23813]