### PR TITLE
Migrate from IcCDK to IcKit

### DIFF
--- a/.github/target_clean
+++ b/.github/target_clean
@@ -2,4 +2,4 @@ Modify the file content to force cargo clean
 which removes the `target` directory
 this is useful for troubleshooting or on a compiler bump, etc.
 
-Last forced clean 202107161633
+Last forced clean 20210908

--- a/piggy-bank/Cargo.toml
+++ b/piggy-bank/Cargo.toml
@@ -7,9 +7,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-cdk = "0.3.0"
-ic-cdk-macros = "0.3.0"
-serde = { version="1.0.116", features = ["derive"] }
+ic-kit = "0.4.0"
+ic-cdk = "0.3.1"
+serde = { version="1.0.130", features = ["derive"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+async-std = { version="1.10.0", features = ["attributes"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/piggy-bank/Cargo.toml
+++ b/piggy-bank/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ic-kit = "0.4.0"
+ic-kit = "0.4.1"
 ic-cdk = "0.3.1"
 serde = { version="1.0.130", features = ["derive"] }
 

--- a/piggy-bank/src/lib.rs
+++ b/piggy-bank/src/lib.rs
@@ -32,7 +32,7 @@ async fn perform_mint(args: PerformMintArgs) -> Result<u64, MintError> {
         .call_with_payment(args.canister, "mint", (Some(account),), args.cycles)
         .await
     {
-        Ok((r,)) => Ok(r),
+        Ok((r,)) => r,
         Err(e) => ic.trap(&format!("Call failed with code={:?}: {}", e.0, e.1)),
     }
 }
@@ -66,7 +66,7 @@ mod tests {
             .with_handler(
                 Method::new()
                     .expect_cycles(300)
-                    .response(17u64)
+                    .response::<Result<u64, MintError>>(Ok(17))
                     .expect_arguments((Some(&alice),)),
             )
             .inject();
@@ -87,7 +87,7 @@ mod tests {
             .with_handler(
                 Method::new()
                     .expect_cycles(140)
-                    .response(18u64)
+                    .response::<Result<u64, MintError>>(Ok(18))
                     .expect_arguments((Some(&bob),)),
             )
             .inject();

--- a/piggy-bank/src/lib.rs
+++ b/piggy-bank/src/lib.rs
@@ -1,6 +1,6 @@
-use ic_cdk::export::candid::{CandidType, Principal};
-use ic_cdk::*;
-use ic_cdk_macros::*;
+use ic_kit::candid::CandidType;
+use ic_kit::macros::*;
+use ic_kit::*;
 use serde::*;
 
 #[derive(Deserialize, CandidType)]
@@ -10,35 +10,117 @@ struct PerformMintArgs {
     cycles: u64,
 }
 
-#[derive(CandidType, Deserialize)]
+#[derive(CandidType, Deserialize, Debug)]
 enum MintError {
     NotSufficientLiquidity,
 }
 
 #[update]
 async fn perform_mint(args: PerformMintArgs) -> Result<u64, MintError> {
+    let ic = get_context();
+
     let account = match args.account {
         Some(account) => account,
-        None => caller(),
+        None => ic.caller(),
     };
 
-    match api::call::call_with_payment(args.canister, "mint", (Some(account),), args.cycles).await {
-        Ok((res,)) => res,
-        Err(e) => trap(&format!("Call failed with code={:?}: {}", e.0, e.1)),
+    if ic.balance() < args.cycles {
+        return Err(MintError::NotSufficientLiquidity);
+    }
+
+    match ic
+        .call_with_payment(args.canister, "mint", (Some(account),), args.cycles)
+        .await
+    {
+        Ok((r,)) => Ok(r),
+        Err(e) => ic.trap(&format!("Call failed with code={:?}: {}", e.0, e.1)),
     }
 }
 
 #[update]
 fn balance() -> u64 {
-    api::canister_balance()
+    get_context().balance()
 }
 
 #[update]
 fn get_available_cycles() -> u64 {
-    api::call::msg_cycles_available()
+    get_context().msg_cycles_available()
 }
 
 #[update]
 fn whoami() -> Principal {
-    caller()
+    get_context().caller()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[async_test]
+    async fn test_mint() {
+        let alice = Principal::from_text("ai7t5-aibaq-aaaaa-aaaaa-c").unwrap();
+        let bob = Principal::from_text("hozae-racaq-aaaaa-aaaaa-c").unwrap();
+
+        MockContext::new()
+            .with_caller(alice.clone())
+            .with_handler(
+                Method::new()
+                    .expect_cycles(300)
+                    .response(17u64)
+                    .expect_arguments((Some(&alice),)),
+            )
+            .inject();
+
+        assert_eq!(
+            perform_mint(PerformMintArgs {
+                canister: Principal::management_canister(),
+                account: None,
+                cycles: 300
+            })
+            .await
+            .unwrap(),
+            17
+        );
+
+        MockContext::new()
+            .with_caller(alice.clone())
+            .with_handler(
+                Method::new()
+                    .expect_cycles(140)
+                    .response(18u64)
+                    .expect_arguments((Some(&bob),)),
+            )
+            .inject();
+
+        assert_eq!(
+            perform_mint(PerformMintArgs {
+                canister: Principal::management_canister(),
+                account: Some(bob),
+                cycles: 140
+            })
+            .await
+            .unwrap(),
+            18
+        );
+    }
+
+    #[async_test]
+    async fn test_balance() {
+        MockContext::new().with_balance(1027).inject();
+        assert_eq!(balance(), 1027);
+    }
+
+    #[async_test]
+    async fn test_get_available_cycles() {
+        MockContext::new().with_msg_cycles(1027).inject();
+        assert_eq!(get_available_cycles(), 1027);
+    }
+
+    #[async_test]
+    async fn test_whoami() {
+        let alice = Principal::from_text("ai7t5-aibaq-aaaaa-aaaaa-c").unwrap();
+        MockContext::new().with_caller(alice).inject();
+
+        assert_eq!(whoami(), alice);
+    }
 }

--- a/xtc/Cargo.toml
+++ b/xtc/Cargo.toml
@@ -7,10 +7,14 @@ edition = "2018"
 [dependencies]
 xtc-history = {path="../xtc-history/xtc-history"}
 xtc-history-common = {path= "../xtc-history/xtc-history-common" }
-ic-cdk = "0.3.0"
-ic-cdk-macros = "0.3.0"
-serde = { version="1.0.116", features = ["derive"] }
 serde_bytes = "0.11"
+ic-kit = "0.4.1"
+ic-cdk = "0.3.1"
+serde = { version="1.0.130", features = ["derive"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+async-std = { version="1.10.0", features = ["attributes"] }
+
 
 [lib]
 crate-type = ["cdylib"]

--- a/xtc/src/cycles_wallet.rs
+++ b/xtc/src/cycles_wallet.rs
@@ -5,7 +5,7 @@ use crate::history::{HistoryBuffer, Transaction, TransactionKind};
 use crate::ledger::Ledger;
 use crate::management::IsShutDown;
 use crate::meta::meta;
-use ic_kit::candid::{CandidType};
+use ic_kit::candid::CandidType;
 use ic_kit::interfaces::management::{
     CanisterSettings, CreateCanister, CreateCanisterArgument, WithCanisterId,
 };
@@ -54,12 +54,7 @@ async fn call(args: CallCanisterArgs) -> Result<CallResult, String> {
     let method_name = args.method_name.clone();
 
     match ic
-        .call_raw(
-            args.canister.clone(),
-            &method_name,
-            args.args,
-            args.cycles,
-        )
+        .call_raw(args.canister.clone(), &method_name, args.args, args.cycles)
         .await
     {
         Ok(x) => {

--- a/xtc/src/history.rs
+++ b/xtc/src/history.rs
@@ -1,10 +1,9 @@
 use crate::stats::{CountTarget, StatsData};
-use ic_cdk::*;
-use ic_cdk_macros::*;
+use ic_kit::macros::*;
+use ic_kit::{get_context, Context, Principal};
 use xtc_history::data::{HistoryArchive, HistoryArchiveBorrowed};
 use xtc_history::History;
 
-use ic_cdk::export::Principal;
 use xtc_history::ic::IcBackend;
 pub use xtc_history_common::types::*;
 
@@ -50,7 +49,7 @@ impl HistoryBuffer {
                 return 0;
             }
 
-            trap("Transaction is expected to have a non-zero amount.")
+            panic!("Transaction is expected to have a non-zero amount.")
         }
 
         StatsData::increment(match &transaction.kind {
@@ -73,18 +72,15 @@ impl HistoryBuffer {
 
 #[update]
 async fn get_transaction(id: TransactionId) -> Option<Transaction> {
-    storage::get::<HistoryBuffer>()
-        .history
-        .get_transaction(id)
-        .await
+    let ic = get_context();
+    ic.get::<HistoryBuffer>().history.get_transaction(id).await
 }
 
 #[query]
 fn events(args: EventsArgs) -> EventsConnection<'static> {
+    let ic = get_context();
     let offset = args.offset;
     let limit = args.limit.min(512);
 
-    storage::get::<HistoryBuffer>()
-        .history
-        .events(offset, limit)
+    ic.get::<HistoryBuffer>().history.events(offset, limit)
 }

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -230,7 +230,7 @@ async fn burn(args: BurnArguments) -> Result<TransactionId, BurnError> {
 #[cfg(test)]
 mod tests {
     use super::Ledger;
-    use ic_kit::Principal;
+    use ic_kit::{Principal, MockContext};
 
     fn alice() -> Principal {
         Principal::from_text("fterm-bydaq-aaaaa-aaaaa-c").unwrap()
@@ -246,6 +246,8 @@ mod tests {
 
     #[test]
     fn balance() {
+        MockContext::new().inject();
+
         let mut ledger = Ledger::default();
         assert_eq!(ledger.balance(&alice()), 0);
         assert_eq!(ledger.balance(&bob()), 0);

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -1,9 +1,9 @@
 use crate::history::{HistoryBuffer, Transaction, TransactionId, TransactionKind};
 use crate::management::IsShutDown;
 use crate::stats::StatsData;
+use ic_kit::candid::CandidType;
 use ic_kit::macros::*;
 use ic_kit::{get_context, Context, Principal};
-use ic_kit::candid::CandidType;
 use serde::*;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -230,7 +230,7 @@ async fn burn(args: BurnArguments) -> Result<TransactionId, BurnError> {
 #[cfg(test)]
 mod tests {
     use super::Ledger;
-    use ic_kit::{Principal, MockContext};
+    use ic_kit::{MockContext, Principal};
 
     fn alice() -> Principal {
         Principal::from_text("fterm-bydaq-aaaaa-aaaaa-c").unwrap()

--- a/xtc/src/ledger.rs
+++ b/xtc/src/ledger.rs
@@ -1,9 +1,9 @@
 use crate::history::{HistoryBuffer, Transaction, TransactionId, TransactionKind};
 use crate::management::IsShutDown;
 use crate::stats::StatsData;
-use ic_cdk::export::candid::{CandidType, Principal};
-use ic_cdk::*;
-use ic_cdk_macros::*;
+use ic_kit::macros::*;
+use ic_kit::{get_context, Context, Principal};
+use ic_kit::candid::CandidType;
 use serde::*;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -72,10 +72,11 @@ impl Ledger {
 
 #[update]
 pub async fn balance(account: Option<Principal>) -> u64 {
-    let user = caller();
+    let ic = get_context();
+    let caller = ic.caller();
     crate::progress().await;
-    let ledger = storage::get::<Ledger>();
-    ledger.balance(&account.unwrap_or_else(|| user))
+    let ledger = ic.get::<Ledger>();
+    ledger.balance(&account.unwrap_or(caller))
 }
 
 #[derive(Deserialize, CandidType)]
@@ -97,27 +98,29 @@ enum TransferError {
 async fn transfer(args: TransferArguments) -> Result<TransactionId, TransferError> {
     IsShutDown::guard();
 
-    let user = caller();
+    let ic = get_context();
+    let caller = ic.caller();
+
     crate::progress().await;
 
-    let ledger = storage::get_mut::<Ledger>();
+    let ledger = ic.get_mut::<Ledger>();
 
     ledger
-        .withdraw(&user, args.amount)
+        .withdraw(&caller, args.amount)
         .map_err(|_| TransferError::InsufficientBalance)?;
     ledger.deposit(args.to, args.amount);
 
     let transaction = Transaction {
-        timestamp: api::time(),
+        timestamp: ic.time(),
         cycles: args.amount,
         fee: 0,
         kind: TransactionKind::Transfer {
-            from: user,
+            from: caller,
             to: args.to,
         },
     };
 
-    let id = storage::get_mut::<HistoryBuffer>().push(transaction);
+    let id = ic.get_mut::<HistoryBuffer>().push(transaction);
     Ok(id)
 }
 
@@ -130,24 +133,26 @@ enum MintError {
 async fn mint(account: Option<Principal>) -> Result<TransactionId, MintError> {
     IsShutDown::guard();
 
-    let user = caller();
+    let ic = get_context();
+    let caller = ic.caller();
+
     crate::progress().await;
 
-    let account = account.unwrap_or_else(|| user);
-    let available = api::call::msg_cycles_available();
-    let accepted = api::call::msg_cycles_accept(available);
+    let account = account.unwrap_or(caller);
+    let available = ic.msg_cycles_available();
+    let accepted = ic.msg_cycles_accept(available);
 
-    let ledger = storage::get_mut::<Ledger>();
+    let ledger = ic.get_mut::<Ledger>();
     ledger.deposit(account.clone(), accepted);
 
     let transaction = Transaction {
-        timestamp: api::time(),
+        timestamp: ic.time(),
         cycles: accepted,
         fee: 0,
         kind: TransactionKind::Mint { to: account },
     };
 
-    let id = storage::get_mut::<HistoryBuffer>().push(transaction);
+    let id = ic.get_mut::<HistoryBuffer>().push(transaction);
     Ok(id)
 }
 
@@ -167,11 +172,14 @@ enum BurnError {
 #[update]
 async fn burn(args: BurnArguments) -> Result<TransactionId, BurnError> {
     IsShutDown::guard();
-    let user = caller();
-    let ledger = storage::get_mut::<Ledger>();
+
+    let ic = get_context();
+    let caller = ic.caller();
+
+    let ledger = ic.get_mut::<Ledger>();
 
     ledger
-        .withdraw(&user, args.amount)
+        .withdraw(&caller, args.amount)
         .map_err(|_| BurnError::InsufficientBalance)?;
 
     #[derive(CandidType)]
@@ -183,28 +191,29 @@ async fn burn(args: BurnArguments) -> Result<TransactionId, BurnError> {
         canister_id: args.canister_id,
     };
 
-    let (result, refunded) = match api::call::call_with_payment(
-        Principal::management_canister(),
-        "deposit_cycles",
-        (deposit_cycles_arg,),
-        args.amount.into(),
-    )
-    .await
+    let (result, refunded) = match ic
+        .call_with_payment(
+            Principal::management_canister(),
+            "deposit_cycles",
+            (deposit_cycles_arg,),
+            args.amount.into(),
+        )
+        .await
     {
         Ok(()) => {
-            let refunded = api::call::msg_cycles_refunded();
+            let refunded = ic.msg_cycles_refunded();
             let cycles = args.amount - refunded;
             let transaction = Transaction {
-                timestamp: api::time(),
+                timestamp: ic.time(),
                 cycles,
                 fee: 0,
                 kind: TransactionKind::Burn {
-                    from: user.clone(),
+                    from: caller.clone(),
                     to: args.canister_id,
                 },
             };
 
-            let id = storage::get_mut::<HistoryBuffer>().push(transaction);
+            let id = ic.get_mut::<HistoryBuffer>().push(transaction);
 
             (Ok(id), refunded)
         }
@@ -212,7 +221,7 @@ async fn burn(args: BurnArguments) -> Result<TransactionId, BurnError> {
     };
 
     if refunded > 0 {
-        ledger.deposit(user, refunded);
+        ledger.deposit(caller, refunded);
     }
 
     result
@@ -221,7 +230,7 @@ async fn burn(args: BurnArguments) -> Result<TransactionId, BurnError> {
 #[cfg(test)]
 mod tests {
     use super::Ledger;
-    use ic_cdk::export::candid::Principal;
+    use ic_kit::Principal;
 
     fn alice() -> Principal {
         Principal::from_text("fterm-bydaq-aaaaa-aaaaa-c").unwrap()

--- a/xtc/src/lib.rs
+++ b/xtc/src/lib.rs
@@ -14,7 +14,7 @@ mod upgrade;
 /// be more things following this design pattern for handling tasks.
 #[inline]
 pub async fn progress() -> bool {
-    use ic_kit::{Context, get_context};
+    use ic_kit::{get_context, Context};
 
     let ic = get_context();
     let history = ic.get_mut::<history::HistoryBuffer>();

--- a/xtc/src/lib.rs
+++ b/xtc/src/lib.rs
@@ -14,8 +14,9 @@ mod upgrade;
 /// be more things following this design pattern for handling tasks.
 #[inline]
 pub async fn progress() -> bool {
-    use ic_cdk::storage;
+    use ic_kit::{Context, get_context};
 
-    let history = storage::get_mut::<history::HistoryBuffer>();
+    let ic = get_context();
+    let history = ic.get_mut::<history::HistoryBuffer>();
     history.progress().await
 }

--- a/xtc/src/meta.rs
+++ b/xtc/src/meta.rs
@@ -1,5 +1,5 @@
-use ic_cdk::export::candid::CandidType;
-use ic_cdk_macros::*;
+use ic_kit::candid::CandidType;
+use ic_kit::macros::*;
 
 #[derive(CandidType)]
 pub struct TokenMetaData<'a> {

--- a/xtc/src/upgrade.rs
+++ b/xtc/src/upgrade.rs
@@ -1,10 +1,10 @@
-use crate::history::{HistoryBuffer};
+use crate::history::HistoryBuffer;
 use crate::ledger::Ledger;
 use crate::management;
 use crate::stats::StatsData;
+use ic_kit::candid::CandidType;
 use ic_kit::macros::*;
 use ic_kit::{get_context, Context, Principal};
-use ic_kit::candid::CandidType;
 use serde::Deserialize;
 use xtc_history::data::{HistoryArchive, HistoryArchiveBorrowed};
 
@@ -52,7 +52,9 @@ pub fn pre_upgrade() {
 #[post_upgrade]
 pub fn post_upgrade() {
     let ic = get_context();
-    let (stable, ) = ic.stable_restore::<(StableStorage,)>().expect("Failed to read from stable storage.");
+    let (stable,) = ic
+        .stable_restore::<(StableStorage,)>()
+        .expect("Failed to read from stable storage.");
     ic.get_mut::<Ledger>().load(stable.ledger);
     ic.get_mut::<HistoryBuffer>().load(stable.history);
     management::Controller::load(stable.controller);


### PR DESCRIPTION
This pull request removes the usage of ic_cdk in the codebase and replaces it with ic_kit to allow more unit testing in future.