### PR TITLE
fix: add clippy to CI and resolve clippy lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,10 @@
 name: Dank Test/Coverage Runner
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+# on:
+#   push:
+#     branches: [ main ]
+#   pull_request:
+#     branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,8 +16,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Lint
+
+    - name: Formatting Check
       run: cargo fmt --all -- --check
+    
+    - name: Clippy Check
+      uses: actions-rs/clippy-check@v1
+      args: -- -D warnings
 
   test:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,6 @@
 name: Dank Test/Coverage Runner
 
-# on:
-#   push:
-#     branches: [ main ]
-#   pull_request:
-#     branches: [ main ]
+on: push
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,8 @@ jobs:
     
     - name: Clippy Check
       uses: actions-rs/clippy-check@v1
-      args: -- -D warnings
+      with:
+        args: -- -D warnings
 
   test:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
+  formatting:
 
     runs-on: ubuntu-latest
 
@@ -19,12 +19,50 @@ jobs:
 
     - name: Formatting Check
       run: cargo fmt --all -- --check
-    
-    - name: Clippy Check
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: -- -D warnings
+      
+  clippy:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/psychedelic/dank-explorer-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.PRIVATE_ACCESS_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Rust toolchain
+        run: .github/scripts/rust-toolchain.sh
+
+      - name: Target clean cache
+        id: target-clean-cache
+        uses: actions/cache@v2
+        with:
+          path: .github/target_clean
+          key: cache-${{ runner.os }}-target-clean-cache-${{ hashFiles('.github/target_clean') }}
+
+      - name: Target dir cache
+        id: target-dir-cache
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: cache-${{ runner.os }}-target-dir-cache-${{ hashFiles('cargo.lock') }}
+
+      - name: Target dir clean
+        # if: steps.target-dir-cache.outputs.cache-hit != 'true' || steps.target-clean-cache.outputs.cache-hit != 'true'
+        run: cargo clean
+
+      - name: Build
+        run: node build.js
+
+      - name: clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D warnings
+      
 
   test:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 name: Dank Test/Coverage Runner
 
-on: push
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Clippy Check
       uses: actions-rs/clippy-check@v1
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         args: -- -D warnings
 
   test:

--- a/piggy-bank/src/lib.rs
+++ b/piggy-bank/src/lib.rs
@@ -17,39 +17,34 @@ enum MintError {
 
 #[update]
 async fn perform_mint(args: PerformMintArgs) -> Result<u64, MintError> {
-    let ic = get_context();
-
     let account = match args.account {
         Some(account) => account,
-        None => ic.caller(),
+        None => ic::caller(),
     };
 
-    if ic.balance() < args.cycles {
+    if ic::balance() < args.cycles {
         return Err(MintError::NotSufficientLiquidity);
     }
 
-    match ic
-        .call_with_payment(args.canister, "mint", (Some(account),), args.cycles)
-        .await
-    {
+    match ic::call_with_payment(args.canister, "mint", (Some(account),), args.cycles).await {
         Ok((r,)) => r,
-        Err(e) => ic.trap(&format!("Call failed with code={:?}: {}", e.0, e.1)),
+        Err(e) => ic::trap(&format!("Call failed with code={:?}: {}", e.0, e.1)),
     }
 }
 
 #[update]
 fn balance() -> u64 {
-    get_context().balance()
+    ic::balance()
 }
 
 #[update]
 fn get_available_cycles() -> u64 {
-    get_context().msg_cycles_available()
+    ic::msg_cycles_available()
 }
 
 #[update]
 fn whoami() -> Principal {
-    get_context().caller()
+    ic::caller()
 }
 
 #[cfg(test)]

--- a/xtc-history/xtc-history-bucket/src/lib.rs
+++ b/xtc-history/xtc-history-bucket/src/lib.rs
@@ -5,18 +5,10 @@ use serde::Deserialize;
 use xtc_history_common::bucket::*;
 use xtc_history_common::types::*;
 
+#[derive(Default)]
 pub struct Data {
     bucket: BucketData,
     controller: Option<Principal>,
-}
-
-impl Default for Data {
-    fn default() -> Self {
-        Self {
-            bucket: BucketData::default(),
-            controller: None,
-        }
-    }
 }
 
 #[init]
@@ -79,5 +71,5 @@ fn get_transaction(id: TransactionId) -> Option<&'static Transaction> {
 fn events(args: EventsArgs) -> EventsConnection<'static> {
     storage::get::<Data>()
         .bucket
-        .events(args.offset, args.limit as usize, || id())
+        .events(args.offset, args.limit as usize, id)
 }

--- a/xtc-history/xtc-history-common/src/bucket.rs
+++ b/xtc-history/xtc-history-common/src/bucket.rs
@@ -119,7 +119,7 @@ impl<Address, Event> BucketData<Address, Event> {
 
         let (offset, limit) = if offset > max {
             let d = (offset - max) as usize;
-            (max, limit.checked_sub(d).unwrap_or(0))
+            (max, limit.saturating_sub(d))
         } else {
             (offset, limit)
         };
@@ -132,7 +132,7 @@ impl<Address, Event> BucketData<Address, Event> {
 
         let take = limit + 1;
         let end = (offset - bucket_offset) as usize;
-        let start = end.checked_sub(take).unwrap_or(0);
+        let start = end.saturating_sub(take);
         let mut data: &[Event] = &self.events[start..end];
 
         let has_more = if data.len() > limit {
@@ -152,7 +152,7 @@ impl<Address, Event> BucketData<Address, Event> {
         };
 
         EventsConnection {
-            data: data.into_iter().rev().collect(),
+            data: data.iter().rev().collect(),
             next_offset,
             next_canister_id,
         }
@@ -177,6 +177,12 @@ impl<Address, Event> BucketData<Address, Event> {
     #[inline]
     pub fn len(&self) -> usize {
         self.events.len()
+    }
+
+    /// Returns `true` if the bucket contains no events.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
     }
 
     /// Update the id of the next canister.

--- a/xtc-history/xtc-history/src/data.rs
+++ b/xtc-history/xtc-history/src/data.rs
@@ -132,7 +132,7 @@ impl<Address> HistoryData<Address> {
     /// Return false if there is no bucket created yet.
     #[inline]
     pub fn bucket_exists(&self) -> bool {
-        self.buckets.len() > 0
+        !self.buckets.is_empty()
     }
 
     /// Return the transaction with the given id using the provided backend storage as type.
@@ -157,9 +157,9 @@ impl<Address> HistoryData<Address> {
         S: Backend<Address>,
         Address: Clone,
     {
-        let offset = offset.unwrap_or(self.size());
+        let offset = offset.unwrap_or_else(|| self.size());
         if offset >= self.bucket.get_offset() {
-            self.bucket.events(Some(offset), limit, || S::id())
+            self.bucket.events(Some(offset), limit, S::id)
         } else {
             EventsConnection {
                 data: Vec::new(),

--- a/xtc-history/xtc-history/src/ic.rs
+++ b/xtc-history/xtc-history/src/ic.rs
@@ -87,7 +87,7 @@ impl Backend<Principal> for IcBackend {
             arg: Vec<u8>,
         }
 
-        let canister_id = canister_id.clone();
+        let canister_id = *canister_id;
 
         Box::pin(async move {
             let install_config = CanisterInstall {
@@ -121,7 +121,7 @@ impl Backend<Principal> for IcBackend {
         canister_id: &Principal,
         metadata: SetBucketMetadataArgs<Principal>,
     ) -> Res<()> {
-        let id = canister_id.clone();
+        let id = *canister_id;
 
         Box::pin(async move {
             match call::call(id, "set_metadata", (metadata,)).await {
@@ -139,7 +139,7 @@ impl Backend<Principal> for IcBackend {
     }
 
     fn append_transactions(canister_id: &Principal, data: &[Transaction]) -> Res<()> {
-        let id = canister_id.clone();
+        let id = *canister_id;
         let args_result = encode_args((data,));
 
         Box::pin(async move {
@@ -160,7 +160,7 @@ impl Backend<Principal> for IcBackend {
     }
 
     fn lookup_transaction(canister_id: &Principal, id: TransactionId) -> Res<Option<Transaction>> {
-        let canister_id = canister_id.clone();
+        let canister_id = *canister_id;
 
         Box::pin(async move {
             let res: Option<Transaction> =

--- a/xtc-history/xtc-history/src/lib.rs
+++ b/xtc-history/xtc-history/src/lib.rs
@@ -48,6 +48,11 @@ impl<Address: Clone + std::cmp::PartialEq, Storage: Backend<Address>> History<Ad
     }
 
     #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    #[inline]
     pub async fn get_transaction(&self, id: TransactionId) -> Option<Transaction> {
         self.data.get_transaction::<Storage>(id).await
     }

--- a/xtc-history/xtc-history/src/mock.rs
+++ b/xtc-history/xtc-history/src/mock.rs
@@ -66,7 +66,7 @@ impl Backend<MockCanisterId> for MockBackend {
         let res = if bucket.len() + data.len() > MOCK_BUCKET_CAPACITY {
             Err("Memory overflow.".to_string())
         } else {
-            bucket.append(&mut data.into_iter().cloned().collect());
+            bucket.append(&mut data.to_vec());
             Ok(())
         };
         Box::pin(async move { res })

--- a/xtc/src/history.rs
+++ b/xtc/src/history.rs
@@ -1,6 +1,6 @@
 use crate::stats::{CountTarget, StatsData};
-use ic_kit::macros::*;
-use ic_kit::{get_context, Context, Principal};
+use ic_kit::Principal;
+use ic_kit::{ic, macros::*};
 use xtc_history::data::{HistoryArchive, HistoryArchiveBorrowed};
 use xtc_history::History;
 
@@ -63,7 +63,7 @@ impl HistoryBuffer {
             TransactionKind::CanisterCreated { .. } => CountTarget::CanisterCreated,
         });
 
-        transaction.timestamp = transaction.timestamp / 1000000;
+        transaction.timestamp /= 1000000;
         self.history.push(transaction)
     }
 
@@ -75,15 +75,13 @@ impl HistoryBuffer {
 
 #[update]
 async fn get_transaction(id: TransactionId) -> Option<Transaction> {
-    let ic = get_context();
-    ic.get::<HistoryBuffer>().history.get_transaction(id).await
+    ic::get::<HistoryBuffer>().history.get_transaction(id).await
 }
 
 #[query]
 fn events(args: EventsArgs) -> EventsConnection<'static> {
-    let ic = get_context();
     let offset = args.offset;
     let limit = args.limit.min(512);
 
-    ic.get::<HistoryBuffer>().history.events(offset, limit)
+    ic::get::<HistoryBuffer>().history.events(offset, limit)
 }

--- a/xtc/src/lib.rs
+++ b/xtc/src/lib.rs
@@ -1,3 +1,7 @@
+#![allow(dead_code)]
+
+use ic_kit::ic;
+
 mod cycles_wallet;
 mod fee;
 mod history;
@@ -18,10 +22,7 @@ mod tests;
 /// be more things following this design pattern for handling tasks.
 #[inline]
 pub async fn progress() -> bool {
-    use ic_kit::{get_context, Context};
-
-    let ic = get_context();
-    let history = ic.get_mut::<history::HistoryBuffer>();
+    let history = ic::get_mut::<history::HistoryBuffer>();
     history.progress().await
 }
 

--- a/xtc/src/management.rs
+++ b/xtc/src/management.rs
@@ -1,26 +1,19 @@
-use ic_kit::macros::*;
-use ic_kit::{get_context, Context, Principal};
+use ic_kit::Principal;
+use ic_kit::{ic, macros::*};
 
 // --- init
 
+#[derive(Default)]
 pub struct Controller(Option<Principal>);
-
-impl Default for Controller {
-    fn default() -> Self {
-        Controller(None)
-    }
-}
 
 impl Controller {
     pub fn load(controller: Principal) {
-        let ic = get_context();
-        let data = ic.get_mut::<Controller>();
+        let data = ic::get_mut::<Controller>();
         data.0 = Some(controller);
     }
 
     pub fn load_if_not_present(controller: Principal) {
-        let ic = get_context();
-        let data = ic.get_mut::<Controller>();
+        let data = ic::get_mut::<Controller>();
         if data.0.is_none() {
             data.0 = Some(controller);
         }
@@ -28,32 +21,24 @@ impl Controller {
 
     #[inline]
     pub fn get_principal() -> Principal {
-        let ic = get_context();
-        ic.get::<Controller>().0.unwrap().clone()
+        ic::get::<Controller>().0.unwrap()
     }
 }
 
 #[init]
 fn init() {
-    let ic = get_context();
-    Controller::load_if_not_present(ic.caller());
+    Controller::load_if_not_present(ic::caller());
 }
 
 // --- halt
 
+#[derive(Default)]
 pub struct IsShutDown(bool);
-
-impl Default for IsShutDown {
-    fn default() -> Self {
-        IsShutDown(false)
-    }
-}
 
 impl IsShutDown {
     #[inline]
     pub fn get() -> bool {
-        let ic = get_context();
-        ic.get::<IsShutDown>().0
+        ic::get::<IsShutDown>().0
     }
 
     #[inline]
@@ -66,20 +51,16 @@ impl IsShutDown {
 
 #[update]
 fn halt() {
-    let ic = get_context();
-
-    if ic.caller() != Controller::get_principal() {
+    if ic::caller() != Controller::get_principal() {
         panic!("Only the controller can call this method.");
     }
 
-    ic.get_mut::<IsShutDown>().0 = true;
+    ic::get_mut::<IsShutDown>().0 = true;
 }
 
 #[update]
 async fn finish_pending_tasks(limit: u32) {
-    let ic = get_context();
-
-    if ic.caller() != Controller::get_principal() {
+    if ic::caller() != Controller::get_principal() {
         panic!("Only the controller can call this method.");
     }
 

--- a/xtc/src/stats.rs
+++ b/xtc/src/stats.rs
@@ -1,7 +1,6 @@
 use crate::history::HistoryBuffer;
 use ic_kit::candid::{CandidType, Nat};
-use ic_kit::macros::*;
-use ic_kit::{get_context, Context};
+use ic_kit::{ic, macros::*};
 use serde::Deserialize;
 
 #[derive(Deserialize, CandidType, Clone, Default)]
@@ -58,24 +57,21 @@ pub enum CountTarget {
 impl StatsData {
     #[inline]
     pub fn load(data: StatsData) {
-        let ic = get_context();
-        let stats = ic.get_mut::<StatsData>();
+        let stats = ic::get_mut::<StatsData>();
         *stats = data;
     }
 
     #[inline]
     pub fn get() -> StatsData {
-        let ic = get_context();
-        let stats = ic.get_mut::<StatsData>();
-        stats.history_events = ic.get::<HistoryBuffer>().len() as u64;
-        stats.balance = ic.balance();
+        let stats = ic::get_mut::<StatsData>();
+        stats.history_events = ic::get::<HistoryBuffer>().len() as u64;
+        stats.balance = ic::balance();
         stats.clone()
     }
 
     #[inline]
     pub fn increment(target: CountTarget) {
-        let ic = get_context();
-        let stats = ic.get_mut::<StatsData>();
+        let stats = ic::get_mut::<StatsData>();
         match target {
             CountTarget::Transfer => stats.transfers_count += 1,
             CountTarget::Mint => stats.mints_count += 1,
@@ -87,22 +83,19 @@ impl StatsData {
 
     #[inline]
     pub fn deposit(amount: u64) {
-        let ic = get_context();
-        let stats = ic.get_mut::<StatsData>();
+        let stats = ic::get_mut::<StatsData>();
         stats.supply += amount;
     }
 
     #[inline]
     pub fn withdraw(amount: u64) {
-        let ic = get_context();
-        let stats = ic.get_mut::<StatsData>();
+        let stats = ic::get_mut::<StatsData>();
         stats.supply -= amount;
     }
 
     #[inline]
     pub fn capture_fee(amount: u64) {
-        let ic = get_context();
-        let stats = ic.get_mut::<StatsData>();
+        let stats = ic::get_mut::<StatsData>();
         stats.fee += amount;
     }
 }


### PR DESCRIPTION
Adds clippy to the CI workflow for `dank`. Resolves all clippy lints as well.

Notable changes:
- I added `#![allow(dead_code)]` to `xtc` to get the lints to pass for the PR, I don't know enough about the project to know if the structs should be re-exported or the modules made public to resolve the dead code lints.